### PR TITLE
fix(playwright): remove /ms-playwright volume mapping and update tests

### DIFF
--- a/mcp_server_registry.yml
+++ b/mcp_server_registry.yml
@@ -413,7 +413,8 @@ servers:
   playwright:
     name: "Playwright MCP Server"
     server_type: "mount_based"
-    description: "Microsoft Playwright browser automation for AI-orchestrated web testing and automation workflows"
+    description: |
+      Microsoft Playwright browser automation for AI-orchestrated web testing and automation workflows
     category: "automation"
     source:
       type: build
@@ -425,7 +426,6 @@ servers:
       - "PLAYWRIGHT_BROWSER_PATH"
       - "PLAYWRIGHT_SCREENSHOTS_PATH"
     volumes:
-      - "PLAYWRIGHT_BROWSER_PATH:/ms-playwright"
       - "PLAYWRIGHT_SCREENSHOTS_PATH:/app/output"
     health_test:
       type: "stdio_jsonrpc"

--- a/spec/integration/mcp_manager_integration_spec.sh
+++ b/spec/integration/mcp_manager_integration_spec.sh
@@ -468,7 +468,8 @@ sh -c 'cd "$PWD/tmp/test_home" && export HOME="$PWD" && zsh "$OLDPWD/mcp_manager
 When run jq -r '.mcpServers.playwright.args[]' tmp/test_home/.cursor/mcp.json
 The status should be success
 The output should include "--volume"
-The output should include ".cache/ms-playwright:/ms-playwright"
+# The browser cache mount is no longer present
+# The output should include ".cache/ms-playwright:/ms-playwright"
 The output should include "screenshots:/app/output"
 The output should include "--output-dir"
 The output should include "local/playwright-mcp-server:latest"


### PR DESCRIPTION
Removes the unnecessary /ms-playwright volume from Playwright MCP server config and updates integration tests to match. Only the screenshots volume is now mounted, matching the correct browser installation behavior. This PR now contains only Playwright-related changes; all unrelated (e.g., Obsidian) changes have been removed.