### PR TITLE
feat: complete Docker security improvements with non-root users for all MCP servers

### DIFF
--- a/support/docker/heroku/Dockerfile
+++ b/support/docker/heroku/Dockerfile
@@ -47,5 +47,13 @@ RUN echo "=== Final verification ===" && \
     heroku version && \
     echo "=== All checks passed ==="
 
+# Create non-root user for security
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup -h /app && \
+    chown -R appuser:appgroup /app
+
+# Switch to non-root user
+USER appuser
+
 # Use the correct entrypoint as specified in PR #67
 ENTRYPOINT ["node", "bin/heroku-mcp-server.mjs"]

--- a/support/docker/mcp-inspector/Dockerfile
+++ b/support/docker/mcp-inspector/Dockerfile
@@ -14,6 +14,11 @@ ENV SERVER_PORT=6277
 RUN apk add --no-cache docker-cli && \
     npm install -g @modelcontextprotocol/inspector@latest
 
+# Create non-root user for security
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup -h /app && \
+    chown -R appuser:appgroup /app
+
 # Expose the ports
 EXPOSE 6274 6277
 
@@ -25,7 +30,11 @@ HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=2 \
 # Create entrypoint script
 RUN echo '#!/bin/sh' > /entrypoint.sh && \
     echo 'exec npx @modelcontextprotocol/inspector "$@"' >> /entrypoint.sh && \
-    chmod +x /entrypoint.sh
+    chmod +x /entrypoint.sh && \
+    chown appuser:appgroup /entrypoint.sh
+
+# Switch to non-root user
+USER appuser
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/support/docker/mcp-server-circleci/Dockerfile
+++ b/support/docker/mcp-server-circleci/Dockerfile
@@ -23,9 +23,18 @@ RUN pnpm run build
 FROM node:lts-alpine
 ENV NODE_ENV=production
 WORKDIR /app
-COPY --from=prod-deps /app/node_modules /app/node_modules
-COPY --from=build /app/dist /app/dist
-COPY package.json ./
+
+# Create non-root user for security
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup -h /app && \
+    chown -R appuser:appgroup /app
+
+COPY --from=prod-deps --chown=appuser:appgroup /app/node_modules /app/node_modules
+COPY --from=build --chown=appuser:appgroup /app/dist /app/dist
+COPY --chown=appuser:appgroup package.json ./
+
+# Switch to non-root user
+USER appuser
 
 # Command to run the MCP server
 ENTRYPOINT ["node", "dist/index.js"]

--- a/support/docker/mcp-server-docker/Dockerfile
+++ b/support/docker/mcp-server-docker/Dockerfile
@@ -21,10 +21,18 @@ FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 
-COPY --from=uv --chown=app:app /app/.venv /app/.venv
+# Create non-root user for security
+RUN groupadd --system --gid 1001 appgroup && \
+    useradd --system --uid 1001 --gid 1001 --no-create-home --home-dir /app appuser && \
+    chown -R appuser:appgroup /app
+
+COPY --from=uv --chown=appuser:appgroup /app/.venv /app/.venv
 
 # Ensure executables in the venv take precedence over system executables
 ENV PATH="/app/.venv/bin:$PATH"
+
+# Switch to non-root user
+USER appuser
 
 # when running the container, add --db-path and a bind mount to the host's db file
 ENTRYPOINT ["mcp-server-docker"]

--- a/support/docker/mcp-server-kubernetes/Dockerfile
+++ b/support/docker/mcp-server-kubernetes/Dockerfile
@@ -7,5 +7,15 @@ RUN make build
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /app
-COPY --from=builder /app/kubernetes-mcp-server /app/kubernetes-mcp-server
+
+# Create non-root user for security
+RUN groupadd --system --gid 1001 appgroup && \
+    useradd --system --uid 1001 --gid 1001 --no-create-home --home-dir /app appuser && \
+    chown -R appuser:appgroup /app
+
+COPY --from=builder --chown=appuser:appgroup /app/kubernetes-mcp-server /app/kubernetes-mcp-server
+
+# Switch to non-root user
+USER appuser
+
 ENTRYPOINT ["/app/kubernetes-mcp-server"]

--- a/support/docker/mcp-server-rails/Dockerfile
+++ b/support/docker/mcp-server-rails/Dockerfile
@@ -18,6 +18,11 @@ RUN gem install rails-mcp-server
 # Create directories for configuration and projects
 RUN mkdir -p /app/config /app/.config/rails-mcp /app/projects
 
+# Create non-root user for security
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup -h /app && \
+    chown -R appuser:appgroup /app /app/.config
+
 # Set up environment variables
 ENV RAILS_MCP_ROOT_PATH=/rails-projects
 ENV RAILS_MCP_CONFIG_HOME=/app/.config
@@ -26,6 +31,9 @@ ENV XDG_CONFIG_HOME=/app/.config
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD rails-mcp-server --help || exit 1
+
+# Switch to non-root user
+USER appuser
 
 # Use the rails-mcp-server executable as entrypoint
 ENTRYPOINT ["rails-mcp-server"]

--- a/support/docker/terraform-cli-controller/Dockerfile
+++ b/support/docker/terraform-cli-controller/Dockerfile
@@ -25,14 +25,24 @@ RUN curl -fsSL https://releases.hashicorp.com/terraform/1.5.7/terraform_1.5.7_li
     rm terraform.zip && \
     chmod +x /usr/local/bin/terraform
 
-# Copy the tfmcp binary from builder
-COPY --from=builder /usr/local/cargo/bin/tfmcp /usr/local/bin/tfmcp
+# Create non-root user for security
+RUN addgroup -g 1001 -S appgroup && \
+    adduser -u 1001 -S appuser -G appgroup -h /app
+
+# Set working directory
+WORKDIR /app
+
+# Copy the tfmcp binary from builder with proper ownership
+COPY --from=builder --chown=appuser:appgroup /usr/local/cargo/bin/tfmcp /usr/local/bin/tfmcp
 
 # Make sure the binary is executable
 RUN chmod +x /usr/local/bin/tfmcp
 
-# Set working directory
-WORKDIR /app
+# Ensure appuser has access to terraform binary
+RUN chown -R appuser:appgroup /app
+
+# Switch to non-root user
+USER appuser
 
 # Set the entrypoint
 ENTRYPOINT ["tfmcp"]


### PR DESCRIPTION
## Summary
Completes the Docker security improvements initiative by implementing non-root user security across all remaining MCP server containers.

• **mcp-inspector**: Added non-root user with npm/Docker CLI access
• **terraform-cli-controller**: Added non-root user with tfmcp binary access  
• **heroku**: Added non-root user with Heroku CLI and Node.js access
• **mcp-server-rails**: Added non-root user with Rails gem system access
• **mcp-server-circleci**: Added non-root user in multi-stage build with proper ownership

## Security Impact
- All 7 custom-built MCP servers now run as non-root users (UID/GID 1001)
- Follows Docker security best practices and principle of least privilege
- Eliminates potential privilege escalation vulnerabilities
- Maintains full functionality and tool accessibility

## Test Plan
- [x] JSON-RPC protocol validation for all modified servers
- [x] Manual functional testing of all 15 MCP servers post-implementation  
- [x] Container lifecycle and permission verification
- [x] Authentication flow validation (GitHub, SonarQube, Heroku, CircleCI)
- [x] Tool/binary accessibility testing for non-root users
- [x] Zero regression testing - all services operational

## Documentation
- [x] Comprehensive development history tracked in Obsidian
- [x] Manual testing report generated (MCP-Server-Test-Report-01-June-2025-10-47)
- [x] Security patterns documented for future implementations

## Related Work
This PR builds on previous security improvements:
- #67: mcp-server-docker security implementation  
- #66: mcp-server-kubernetes security implementation

All MCP servers in the MacbookSetup project now follow consistent Docker security standards.